### PR TITLE
Package version bump and fixed BT traversals

### DIFF
--- a/packages/visualizer_component/package-lock.json
+++ b/packages/visualizer_component/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@c-degni/algo-vis",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@c-degni/algo-vis",
-            "version": "1.3.0",
+            "version": "1.4.0",
             "devDependencies": {
                 "typescript": "^5.9.2"
             }

--- a/packages/visualizer_component/package.json
+++ b/packages/visualizer_component/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@c-degni/algo-vis",
-    "version": "1.3.0",
+    "version": "1.4.0",
     "main": "dist/index.js",
     "author": "Christ Degni",
     "license": "MIT",

--- a/packages/visualizer_component/src/VisualizationContainer.tsx
+++ b/packages/visualizer_component/src/VisualizationContainer.tsx
@@ -3,6 +3,7 @@ import ExecutionPlayer from '../../../src/components/shared/ExecutionPlayer';
 import StackVisualizer from '../../../src/components/visualizers/data_structures/StackVisualizer';
 import QueueVisualizer from '../../../src/components/visualizers/data_structures/QueueVisualizer';
 import LinkedListVisualizer from '../../../src/components/visualizers/data_structures/LinkedListVisualizer';
+import BinaryTreeVisualizer from '../../../src/components/visualizers/data_structures/BinaryTreeVisualizer';
 
 interface Operation {
     type: string;
@@ -11,7 +12,7 @@ interface Operation {
 
 interface VisualizationContainerProps {
     apiEndpoint: string;
-    dataStructure: 'stack' | 'queue' | 'linkedlist';
+    dataStructure: 'stack' | 'queue' | 'linkedlist' | 'binarytree';
     dataType: 'int' | 'double' | 'float' | 'bool' | 'string';
     operations: Operation[];
     onError?: (error: string) => void;
@@ -79,6 +80,14 @@ export default function VisualizationContainer({
                 return (
                     <LinkedListVisualizer
                         elements={currentState?.elements || []}
+                        highlights={currentHighlights}
+                    />
+                );
+            case 'binarytree':
+                return (
+                    <BinaryTreeVisualizer
+                        inorder={currentState?.inorder || []}
+                        preorder={currentState?.preorder || []}
                         highlights={currentHighlights}
                     />
                 );

--- a/packages/visualizer_component/src/index.ts
+++ b/packages/visualizer_component/src/index.ts
@@ -2,4 +2,5 @@ export { default as ExecutionPlayer } from '../../../src/components/shared/Execu
 export { default as StackVisualizer } from '../../../src/components/visualizers/data_structures/StackVisualizer';
 export { default as QueueVisualizer } from '../../../src/components/visualizers/data_structures/QueueVisualizer';
 export { default as LinkedListVisualizer } from '../../../src/components/visualizers/data_structures/LinkedListVisualizer';
+export { default as BinaryTreeVisualizer } from '../../../src/components/visualizers/data_structures/BinaryTreeVisualizer';
 export { default as VisualizationContainer } from './VisualizationContainer';

--- a/src/visualization_mapping/cpp/data_structures/TrackedBinaryTree.h
+++ b/src/visualization_mapping/cpp/data_structures/TrackedBinaryTree.h
@@ -128,7 +128,7 @@ std::string TrackedBinaryTree<T>::inorder() {
     res = inorder(res, root);
 
     std::string str;
-    for (T item : res) str += stringify(item);
+    for (T item : res) str += (stringify(item) + " ");
     
     recordOp(
         "inorder",
@@ -155,7 +155,7 @@ std::string TrackedBinaryTree<T>::preorder() {
     res = preorder(res, root);
 
     std::string str;
-    for (T item : res) str += stringify(item);
+    for (T item : res) str += (stringify(item) + " ");
     
     recordOp(
         "preorder",

--- a/src/visualization_mapping/cpp/translation/BinaryTreeWrapper.cpp
+++ b/src/visualization_mapping/cpp/translation/BinaryTreeWrapper.cpp
@@ -15,8 +15,8 @@ class TypeName##BinaryTreeWrapper : public Napi::ObjectWrap<TypeName##BinaryTree
                 InstanceMethod("find", &TypeName##BinaryTreeWrapper::Find),                                                         \
                 InstanceMethod("size", &TypeName##BinaryTreeWrapper::Size),                                                         \
                 InstanceMethod("getHeight", &TypeName##BinaryTreeWrapper::GetHeight),                                               \
-                InstanceMethod("inorder", &TypeName##BinaryTreeWrapper::Preorder),                                                  \
-                InstanceMethod("preorder", &TypeName##BinaryTreeWrapper::Inorder),                                                  \
+                InstanceMethod("inorder", &TypeName##BinaryTreeWrapper::Inorder),                                                  \
+                InstanceMethod("preorder", &TypeName##BinaryTreeWrapper::Preorder),                                                  \
                 InstanceMethod("postorder", &TypeName##BinaryTreeWrapper::Postorder),                                               \
                 InstanceMethod("inTree", &TypeName##BinaryTreeWrapper::InTree),                                                     \
                 InstanceMethod("getTrace", &TypeName##BinaryTreeWrapper::GetTrace)                                                  \


### PR DESCRIPTION
- Package version bump w bt implementation: `1.3.0` -> `1.4.0`
- Fixed swapped binary tree traversals and modified traversal presentation